### PR TITLE
fix: golangci.ymlをv2形式に移行

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -2,20 +2,18 @@ version: "2"
 
 linters:
   # 全ての linter を無効化
-  disable-all: true
+  default: none
   # 指定した linter のみ有効化
   enable:
     - govet
     - errcheck
     - staticcheck
     - revive
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
 
 run:
-  timeout: 5m
   tests: true
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - errcheck


### PR DESCRIPTION
## Summary
- `golangci.yml` に残っていたv1形式のキーをv2スキーマに移行
  - `linters.disable-all: true` → `linters.default: none`
  - `issues.exclude-rules` → `linters.exclusions.rules`
  - `run.timeout`（v2で廃止、CI側の `--timeout=5m` フラグで指定済みのため削除）

## Background
v1形式のキーはv2では無視されるため、`disable-all: true` が効かず意図しない linter（`ineffassign`, `unused`）が有効化されていた。

修正前: `Active 6 linters: [errcheck govet ineffassign revive staticcheck unused]`
修正後: `Active 4 linters: [errcheck govet revive staticcheck]`

## Test plan
- [x] `golangci-lint run --config golangci.yml -v` で有効な linter が意図通り4つ（govet, errcheck, staticcheck, revive）であることを確認
- [x] `_test\.go` に対する errcheck の除外ルールが認識されていることをログで確認（`[runner/exclusion_rules] Skipped ... rules: [Path: "_test\\.go", Linters: "errcheck"]`）

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)