### PR TITLE
fix: --check-exifの終了コード修正とtest-cases.mdの記述更新

### DIFF
--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -15,7 +15,7 @@ HEIC Image Converterの機能要件および非機能要件を満たしている
 ### 1.3 テスト環境
 
 - OS: macOS, Linux, Windows
-- Go: 1.23以上
+- Go: 1.25.6以上
 - テストデータ: HEIC形式の画像ファイル（EXIF情報あり/なし）
 
 ### 1.4 テスト実行方法
@@ -40,7 +40,7 @@ go test -v ./...
 
 #### テストの詳細情報
 
-- **テストファイル**: `main_test.go`に実装されています
+- **テストファイル**: `internal/`配下の各パッケージに実装されています（`internal/cli/root_test.go`、`internal/converter/converter_test.go`、`internal/exif/exif_test.go`）
 - **テストデータ**: `sample/test.HEIC`をテストデータとして使用します
 - **テスト実行時**: このファイルが一時ディレクトリに複製されて使用されます
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -90,7 +90,8 @@ func runCheckEXIF(args []string) error {
 	// パスの存在確認
 	info, err := os.Stat(targetPath)
 	if err != nil {
-		return fmt.Errorf("パスが見つかりません: %w", err)
+		fmt.Printf("警告: ファイルまたはディレクトリが見つかりません: %s\n", targetPath)
+		return nil
 	}
 
 	var jpegFiles []string
@@ -140,6 +141,10 @@ func runCheckEXIF(args []string) error {
 	fmt.Printf("EXIF削除済み: %d\n", noEXIFCount)
 	fmt.Printf("EXIF残存: %d\n", hasEXIFCount)
 	fmt.Printf("エラー: %d\n", errorCount)
+
+	if hasEXIFCount > 0 {
+		return fmt.Errorf("EXIF情報が残っているファイルがあります（%d件）", hasEXIFCount)
+	}
 
 	return nil
 }
@@ -229,7 +234,7 @@ func runConvertMode(args []string) error {
 	}
 
 	if len(heicFiles) == 0 {
-		fmt.Println("変換対象のHEICファイルが見つかりませんでした。")
+		fmt.Println("HEICファイルが見つかりませんでした。")
 		return nil
 	}
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -450,7 +450,7 @@ func TestRunConvertMode_TC00602(t *testing.T) {
 	}
 }
 
-// TestRunCheckEXIF_TC00801 tests TC-008-01, TC-008-02: Check EXIF for single file
+// TestRunCheckEXIF_TC00801 tests TC-008-01: Check EXIF for single file (EXIF remains)
 func TestRunCheckEXIF_TC00801(t *testing.T) {
 	resetFlags()
 	defer resetFlags()
@@ -461,9 +461,41 @@ func TestRunCheckEXIF_TC00801(t *testing.T) {
 	tmpDir, cleanup := setupTestEnvironment(t)
 	defer cleanup()
 
-	// First convert HEIC to JPEG
+	// First convert HEIC to JPEG, then copy EXIF over (mirrors runConvertMode's flow)
 	heicFile := filepath.Join(tmpDir, "test.HEIC")
 	options := converter.ConvertOptions{RemoveEXIF: false}
+	if err := converter.ConvertHEICToJPEG(heicFile, options); err != nil {
+		t.Fatalf("Failed to convert HEIC: %v", err)
+	}
+
+	jpegFile := converter.GenerateOutputPath(heicFile)
+	if err := exif.CopyEXIFFromHEICToJPEG(heicFile, jpegFile); err != nil {
+		t.Fatalf("Failed to copy EXIF: %v", err)
+	}
+
+	// Check EXIF
+	args := []string{jpegFile}
+	err := runCheckEXIF(args)
+	// EXIF remains, so the exit code must be non-zero (error)
+	if err == nil {
+		t.Fatal("Expected error because EXIF data remains, got nil")
+	}
+}
+
+// TestRunCheckEXIF_TC00802 tests TC-008-02: Check EXIF for single file (EXIF removed)
+func TestRunCheckEXIF_TC00802(t *testing.T) {
+	resetFlags()
+	defer resetFlags()
+
+	checkEXIF = true
+	defer resetFlags()
+
+	tmpDir, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Convert HEIC to JPEG without copying EXIF over, so no EXIF is embedded
+	heicFile := filepath.Join(tmpDir, "test.HEIC")
+	options := converter.ConvertOptions{RemoveEXIF: true}
 	if err := converter.ConvertHEICToJPEG(heicFile, options); err != nil {
 		t.Fatalf("Failed to convert HEIC: %v", err)
 	}
@@ -473,7 +505,7 @@ func TestRunCheckEXIF_TC00801(t *testing.T) {
 	// Check EXIF
 	args := []string{jpegFile}
 	err := runCheckEXIF(args)
-	// Should not error
+	// No EXIF remains, so the exit code must be zero (no error)
 	if err != nil {
 		t.Fatalf("runCheckEXIF failed: %v", err)
 	}
@@ -500,15 +532,20 @@ func TestRunCheckEXIF_TC00803(t *testing.T) {
 	for _, heicFile := range heicFiles {
 		if err := converter.ConvertHEICToJPEG(heicFile, options); err != nil {
 			t.Logf("Failed to convert %s: %v", heicFile, err)
+			continue
+		}
+		jpegFile := converter.GenerateOutputPath(heicFile)
+		if err := exif.CopyEXIFFromHEICToJPEG(heicFile, jpegFile); err != nil {
+			t.Logf("Failed to copy EXIF for %s: %v", heicFile, err)
 		}
 	}
 
 	// Check EXIF in directory
 	args := []string{tmpDir}
 	err = runCheckEXIF(args)
-	// Should not error
-	if err != nil {
-		t.Fatalf("runCheckEXIF failed: %v", err)
+	// EXIF remains in the converted files, so the exit code must be non-zero (error)
+	if err == nil {
+		t.Fatal("Expected error because EXIF data remains, got nil")
 	}
 }
 
@@ -523,9 +560,10 @@ func TestRunCheckEXIF_TC00804(t *testing.T) {
 	tmpDir, cleanup := setupTestEnvironment(t)
 	defer cleanup()
 
-	// Convert HEIC to JPEG
+	// Convert HEIC to JPEG, removing EXIF so this test stays focused on
+	// current-directory scanning rather than the exit-code behavior (covered by TC-008-01/02/03)
 	heicFile := filepath.Join(tmpDir, "test.HEIC")
-	options := converter.ConvertOptions{RemoveEXIF: false}
+	options := converter.ConvertOptions{RemoveEXIF: true}
 	if err := converter.ConvertHEICToJPEG(heicFile, options); err != nil {
 		t.Fatalf("Failed to convert HEIC: %v", err)
 	}
@@ -589,9 +627,9 @@ func TestRunCheckEXIF_TC00806(t *testing.T) {
 	args := []string{"nonexistent.jpg"}
 	err := runCheckEXIF(args)
 
-	// Should error for nonexistent file
-	if err == nil {
-		t.Fatal("Expected error for nonexistent file, got nil")
+	// A warning is printed and processing continues, so no error is returned
+	if err != nil {
+		t.Fatalf("Expected no error for nonexistent file (warning + continue), got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `--check-exif` の終了コード・エラーハンドリングを `docs/test-cases.md` の仕様（TC-008-01, TC-008-03, TC-008-06）に合わせて修正
  - EXIF残存ファイルがある場合は終了コード1を返すよう修正
  - 存在しないパス指定時は警告を表示して処理を継続するよう修正（従来はエラー終了）
  - 変換対象0件時のメッセージを仕様どおり「HEICファイルが見つかりませんでした。」に統一
- `docs/test-cases.md` の古い記述（テストファイル構成、Goバージョン）を実装に合わせて更新

Closes #25
Closes #28

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] ビルドしたバイナリで `--check-exif` の終了コード・警告表示を手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)