### PR TITLE
fix: ExtractEXIFFromHEICでEXIFなしと抽出エラーを区別する

### DIFF
--- a/internal/exif/exif.go
+++ b/internal/exif/exif.go
@@ -3,6 +3,7 @@
 package exif
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,10 +11,16 @@ import (
 	"strings"
 
 	"github.com/adrium/goheif"
+	"github.com/adrium/goheif/heif"
 	exifv3 "github.com/dsoprea/go-exif/v3"
 	exifcommon "github.com/dsoprea/go-exif/v3/common"
 	jpegstructure "github.com/dsoprea/go-jpeg-image-structure/v2"
 )
+
+// ErrNoEXIF is returned by ExtractEXIFFromHEIC when the HEIC file does not
+// contain any EXIF data. Callers can use errors.Is to distinguish this from
+// an actual extraction failure (e.g. a corrupted file).
+var ErrNoEXIF = errors.New("EXIF情報が存在しません")
 
 // ExtractEXIFFromHEIC extracts EXIF data from a HEIC file
 func ExtractEXIFFromHEIC(heicPath string) ([]byte, error) {
@@ -31,12 +38,14 @@ func ExtractEXIFFromHEIC(heicPath string) ([]byte, error) {
 	// Extract EXIF data from HEIC file
 	exifBytes, err := goheif.ExtractExif(file)
 	if err != nil {
-		// EXIFが存在しない場合は空のスライスを返す
-		return nil, nil
+		if errors.Is(err, heif.ErrNoEXIF) {
+			return nil, ErrNoEXIF
+		}
+		return nil, fmt.Errorf("HEICファイルからのEXIF抽出に失敗しました: %w", err)
 	}
 
 	if len(exifBytes) == 0 {
-		return nil, nil
+		return nil, ErrNoEXIF
 	}
 
 	return exifBytes, nil
@@ -242,6 +251,12 @@ func ShowEXIFFromHEIC(heicPath string) error {
 	// Extract EXIF data from HEIC
 	exifBytes, err := ExtractEXIFFromHEIC(heicPath)
 	if err != nil {
+		if errors.Is(err, ErrNoEXIF) {
+			fmt.Printf("=== EXIF情報: %s ===\n", filepath.Base(heicPath))
+			fmt.Println("EXIF情報: なし")
+			fmt.Println()
+			return nil
+		}
 		return fmt.Errorf("HEICファイルからEXIF情報の抽出に失敗しました: %w", err)
 	}
 
@@ -452,6 +467,10 @@ func CopyEXIFFromHEICToJPEG(heicPath, jpegPath string) error {
 	// Try to extract EXIF from HEIC
 	exifData, err := ExtractEXIFFromHEIC(heicPath)
 	if err != nil {
+		if errors.Is(err, ErrNoEXIF) {
+			// No EXIF data in HEIC file
+			return nil
+		}
 		return fmt.Errorf("HEICファイルからEXIF情報の抽出に失敗しました: %w", err)
 	}
 

--- a/internal/exif/exif_test.go
+++ b/internal/exif/exif_test.go
@@ -1,6 +1,7 @@
 package exif
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -329,6 +330,47 @@ func TestExtractEXIFFromHEIC(t *testing.T) {
 	// This is expected as it's a placeholder
 	if exifData != nil {
 		t.Logf("EXIF data extracted: %d bytes", len(exifData))
+	}
+}
+
+// TestExtractEXIFFromHEIC_InvalidFile tests that a genuine extraction failure
+// (e.g. a corrupted/non-HEIC file) is reported as an error distinct from
+// ErrNoEXIF, so callers don't silently treat it as "no EXIF present".
+func TestExtractEXIFFromHEIC_InvalidFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	invalidFile := filepath.Join(tmpDir, "invalid.HEIC")
+	if err := os.WriteFile(invalidFile, []byte("this is not a valid HEIC file"), 0644); err != nil {
+		t.Fatalf("Failed to write invalid test file: %v", err)
+	}
+
+	exifData, err := ExtractEXIFFromHEIC(invalidFile)
+	if err == nil {
+		t.Fatal("Expected error for invalid HEIC file, got nil")
+	}
+	if errors.Is(err, ErrNoEXIF) {
+		t.Fatalf("Expected a real extraction error, got ErrNoEXIF: %v", err)
+	}
+	if exifData != nil {
+		t.Errorf("Expected nil EXIF data on error, got %d bytes", len(exifData))
+	}
+}
+
+// TestShowEXIFFromHEIC_InvalidFile tests that ShowEXIFFromHEIC surfaces a
+// genuine extraction failure as an error instead of silently reporting
+// "EXIF情報: なし".
+func TestShowEXIFFromHEIC_InvalidFile(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	invalidFile := filepath.Join(tmpDir, "invalid.HEIC")
+	if err := os.WriteFile(invalidFile, []byte("this is not a valid HEIC file"), 0644); err != nil {
+		t.Fatalf("Failed to write invalid test file: %v", err)
+	}
+
+	if err := ShowEXIFFromHEIC(invalidFile); err == nil {
+		t.Fatal("Expected error for invalid HEIC file, got nil")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ExtractEXIFFromHEIC` が `goheif.ExtractExif` のエラーを一律 `nil, nil` として握りつぶし、EXIFなしと実際の抽出失敗（壊れたファイル等）を区別できていなかった問題を修正
- センチネルエラー `exif.ErrNoEXIF` を追加し、`heif.ErrNoEXIF` の場合のみそれを返すように変更。それ以外のエラーは呼び出し元にラップして伝播させる
- `ShowEXIFFromHEIC` / `CopyEXIFFromHEICToJPEG` を `errors.Is(err, ErrNoEXIF)` で分岐するように更新し、実際のエラーは正しく伝播するように修正

Closes #26

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./...` (全パッケージ成功)
- [x] 新規テスト: 破損HEICファイルに対して `ExtractEXIFFromHEIC` / `ShowEXIFFromHEIC` が `ErrNoEXIF` ではなく実際のエラーを返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)