### PR TITLE
fix: workflowのGoバージョン指定をgo-version-fileに統一

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25.6"
+          go-version-file: 'go.mod'
 
       - name: Install dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25.6"
+          go-version-file: 'go.mod'
 
       - name: Install dependencies (Linux)
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25.6"
+          go-version-file: 'go.mod'
 
       - name: Install dependencies
         run: go mod download


### PR DESCRIPTION
## Summary
- `test.yml` / `build.yml` / `release.yml` にハードコードされていた `go-version: "1.25.6"` を `go-version-file: 'go.mod'` に統一
- `lint.yml` は既に `go-version-file` を使っており、go.mod更新時にバージョンがずれる問題を解消

## Test plan
- [x] 各workflowファイルのYAML構文を確認

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)